### PR TITLE
PSQL test database creation in custom target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,14 @@ jobs:
             mkdir -p /ws/cogutil/build
             cd /ws/cogutil/build && cmake .. && make -j2 && make -j2 install
             ldconfig
-      - run:
-          name: Remove link-grammar "any" tokenization
+      #- run:
+      #    name: Remove link-grammar "any" tokenization
             # The current ULL pipeline is tokenization-agnostic, so the input
             # should be pre-tokenized by some other method. The pipeline only
             # splits sentences by spaces. For the tests to work, we need to
             # remove the content of the affix-file in the link-grammar dictionary
             # for "any" language. For the test suite, it is done below.
-          command: echo "" > /usr/local/share/link-grammar/any/affix-punc
+      #    command: echo "" > /usr/local/share/link-grammar/any/affix-punc
       - run:
           name: Checkout AtomSpace
           command: git clone --depth 1 https://github.com/singnet/atomspace /ws/atomspace
@@ -89,12 +89,12 @@ jobs:
       - run:
           name: Build
           command: cd build && make -j2
-      - run:
-          name: Build tests
-          command: cd build && make -j2 test
+      #- run:
+      #    name: Build tests
+      #    command: cd build && make -j2 test
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make db && make -j2 test ARGS=-j2
       - run:
           name: Install learn
           command: cd build && make -j2 install && ldconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,12 +89,12 @@ jobs:
       - run:
           name: Build
           command: cd build && make -j2
-      #- run:
-      #    name: Build tests
-      #    command: cd build && make -j2 test
+      - run:
+          name: Reset databases
+          command: cd build && make -j2 db
       - run:
           name: Run tests
-          command: cd build && make db && make -j2 test ARGS=-j2
+          command: cd build && make -j2 test ARGS=-j2
       - run:
           name: Install learn
           command: cd build && make -j2 install && ldconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: cd build && make -j2 db
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make test
       - run:
           name: Install learn
           command: cd build && make -j2 install && ldconfig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,46 +5,75 @@ PROJECT(learn)
 # Cogutil
 FIND_PACKAGE(CogUtil 2.0.3 CONFIG REQUIRED)
 IF(COGUTIL_FOUND)
-  ADD_DEFINITIONS(-DHAVE_COGUTIL)
-  SET(HAVE_COGUTIL 1)
+	ADD_DEFINITIONS(-DHAVE_COGUTIL)
+	SET(HAVE_COGUTIL 1)
 
-  # Add the 'cmake' directory from cogutil to search path
-  list(APPEND CMAKE_MODULE_PATH  ${COGUTIL_DATA_DIR}/cmake)
+	# Add the 'cmake' directory from cogutil to search path
+	list(APPEND CMAKE_MODULE_PATH  ${COGUTIL_DATA_DIR}/cmake)
 ENDIF()
 
 # AtomSpace
 FIND_PACKAGE(AtomSpace 5.0.4 CONFIG REQUIRED)
 IF(ATOMSPACE_FOUND)
-  ADD_DEFINITIONS(-DHAVE_ATOMSPACE)
-  SET(HAVE_ATOMSPACE 1)
+	ADD_DEFINITIONS(-DHAVE_ATOMSPACE)
+	SET(HAVE_ATOMSPACE 1)
 ENDIF()
 
 # Guile
 FIND_PACKAGE(Guile 2.2.2 REQUIRED)
 IF(GUILE_FOUND)
-  ADD_DEFINITIONS(-DHAVE_GUILE)
-  SET(HAVE_GUILE 1)
+	ADD_DEFINITIONS(-DHAVE_GUILE)
+	SET(HAVE_GUILE 1)
 ENDIF()
 
 # Load cmake functions defined in cogutil repo that depend on Guile.
 IF(GUILE_FOUND AND COGUTIL_FOUND)
-  INCLUDE("${COGUTIL_DATA_DIR}/cmake/OpenCogFunctions.cmake")
+	INCLUDE("${COGUTIL_DATA_DIR}/cmake/OpenCogFunctions.cmake")
 ENDIF()
 
 # Used for configuring experimental setup. Run 'make run-ull' from build
 # directory to configure the setup for expirmenting with code in run-poc.
 # NOTE: The order of the command matters, so test after making changes.
 ADD_CUSTOM_TARGET(run-ull
-  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/run-poc"
-    "${PROJECT_BINARY_DIR}/run-ull"
-  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/run/nonbreaking_prefixes/"
-    "${PROJECT_BINARY_DIR}/run-ull/nonbreaking_prefixes/"
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/run/split-sentences.pl"
-    "${PROJECT_BINARY_DIR}/run-ull/"
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/run/config/*"
-    "${PROJECT_BINARY_DIR}/run-ull/config"
-  WORKING_DIRECTORY ${CURRENT_SOURCE_DIR}
-  COMMENT "Setting run-ull in ${PROJECT_BINARY_DIR}/run-ull"
+	COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/run-poc"
+		"${PROJECT_BINARY_DIR}/run-ull"
+	COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/run/nonbreaking_prefixes/"
+		"${PROJECT_BINARY_DIR}/run-ull/nonbreaking_prefixes/"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/run/split-sentences.pl"
+		"${PROJECT_BINARY_DIR}/run-ull/"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/run/config/*"
+		"${PROJECT_BINARY_DIR}/run-ull/config"
+	WORKING_DIRECTORY ${CURRENT_SOURCE_DIR}
+	COMMENT "Setting run-ull in ${PROJECT_BINARY_DIR}/run-ull"
+)
+
+MESSAGE("Curr dir: ${CMAKE_SOURCE_DIR}")
+
+ADD_CUSTOM_TARGET(db
+	# Reset all test databases needed
+	VERBATIM
+	COMMAND bash -c "dropdb --if-exists ULL_tests"
+	COMMAND bash -c "createdb ULL_tests"
+	COMMAND bash -c "cat ${CMAKE_SOURCE_DIR}/run-poc/atom.sql | psql ULL_tests"
+	COMMENT "\nCreated database ULL_tests.\n"
+
+	COMMAND bash -c "dropdb --if-exists ULL_calcMI_clique_test"
+	COMMAND bash -c "createdb ULL_calcMI_clique_test"
+	COMMAND bash -c "cat ${CMAKE_SOURCE_DIR}/run-poc/atom.sql | psql ULL_calcMI_clique_test"
+	COMMENT "\nCreated database ULL_calcMI_clique_test.\n"
+
+	COMMAND bash -c "dropdb --if-exists ULL_calcMI_any_test"
+	COMMAND bash -c "createdb ULL_calcMI_any_test"
+	COMMAND bash -c "cat ${CMAKE_SOURCE_DIR}/run-poc/atom.sql | psql ULL_calcMI_any_test"
+	COMMENT "\nCreated database ULL_calcMI_any_test.\n"
+
+	# The current ULL pipeline is tokenization-agnostic, so the input
+	# should be pre-tokenized by some other method. The pipeline only
+	# splits sentences by spaces. For the tests to work, we need to
+	# remove the content of the affix-file in the link-grammar dictionary
+	# for "any" language. For the test suite, it is done below.
+	COMMAND bash -c "if [ ! -f /usr/local/share/link-grammar/any/affix-punc-original ]; then sudo cp /usr/local/share/link-grammar/any/affix-punc /usr/local/share/link-grammar/any/affix-punc-original; fi"
+	COMMAND bash -c "echo '' > tmp; sudo mv tmp /usr/local/share/link-grammar/any/affix-punc"
 )
 
 ADD_SUBDIRECTORY (scm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,31 +47,30 @@ ADD_CUSTOM_TARGET(run-ull
 	COMMENT "Setting run-ull in ${PROJECT_BINARY_DIR}/run-ull"
 )
 
-MESSAGE("Curr dir: ${CMAKE_SOURCE_DIR}")
-
 ADD_CUSTOM_TARGET(db
 	# Reset all test databases needed
 	VERBATIM
 	COMMAND bash -c "dropdb --if-exists ULL_tests"
 	COMMAND bash -c "createdb ULL_tests"
 	COMMAND bash -c "cat ${CMAKE_SOURCE_DIR}/run-poc/atom.sql | psql ULL_tests"
-	COMMENT "\nCreated database ULL_tests.\n"
+	COMMAND bash -c "echo 'Created database ULL_tests.'"
 
 	COMMAND bash -c "dropdb --if-exists ULL_calcMI_clique_test"
 	COMMAND bash -c "createdb ULL_calcMI_clique_test"
 	COMMAND bash -c "cat ${CMAKE_SOURCE_DIR}/run-poc/atom.sql | psql ULL_calcMI_clique_test"
-	COMMENT "\nCreated database ULL_calcMI_clique_test.\n"
+	COMMAND bash -c "echo 'Created database ULL_calcMI_clique_test.'"
 
 	COMMAND bash -c "dropdb --if-exists ULL_calcMI_any_test"
 	COMMAND bash -c "createdb ULL_calcMI_any_test"
 	COMMAND bash -c "cat ${CMAKE_SOURCE_DIR}/run-poc/atom.sql | psql ULL_calcMI_any_test"
-	COMMENT "\nCreated database ULL_calcMI_any_test.\n"
+	COMMAND bash -c "echo 'Created database ULL_calcMI_any_test.'"
 
 	# The current ULL pipeline is tokenization-agnostic, so the input
 	# should be pre-tokenized by some other method. The pipeline only
 	# splits sentences by spaces. For the tests to work, we need to
 	# remove the content of the affix-file in the link-grammar dictionary
 	# for "any" language. For the test suite, it is done below.
+	COMMAND bash -c "echo ''; echo 'Backing up and clearing affix file for LG any'"
 	COMMAND bash -c "if [ ! -f /usr/local/share/link-grammar/any/affix-punc-original ]; then sudo cp /usr/local/share/link-grammar/any/affix-punc /usr/local/share/link-grammar/any/affix-punc-original; fi"
 	COMMAND bash -c "echo '' > tmp; sudo mv tmp /usr/local/share/link-grammar/any/affix-punc"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,3 +78,4 @@ ADD_CUSTOM_TARGET(db
 ADD_SUBDIRECTORY (scm)
 ADD_SUBDIRECTORY (tests)
 ENABLE_TESTING()
+MESSAGE("Before running 'make test', make sure to 'make db'")

--- a/run-poc/alpha-pages/test-mi-pairs.ipw
+++ b/run-poc/alpha-pages/test-mi-pairs.ipw
@@ -1,4 +1,4 @@
-###LEFT-WALL### A mom is a human .
+A mom is a human .
 0 ###LEFT-WALL### 1 A 0.1
 0 ###LEFT-WALL### 2 mom 0.1
 0 ###LEFT-WALL### 3 is 0.1
@@ -36,7 +36,7 @@
 6 . 4 a 0.45
 6 . 5 human 0.55
 
-###LEFT-WALL### A dad is a human .
+A dad is a human .
 0 ###LEFT-WALL### 1 A 0.1
 0 ###LEFT-WALL### 2 dad 0.1
 0 ###LEFT-WALL### 3 is 0.1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,38 +7,13 @@
 
 # If you're using an opencog docker container, psql should
 # already be set up.
-
-ENABLE_TESTING()
-
 # Set postgress credentials
 if(NOT DEFINED ENV{PGUSER})
 	SET(ENV{PGUSER} $ENV{USER})
 endif(NOT DEFINED ENV{PGUSER})
 SET(ENV{PGPASSWORD} "cheese")
 
-# Reset all test databases needed
-message("\nIf database doesn't exist, dropdb sends error message. Disregard it.\n")
-execute_process(COMMAND "dropdb" "ULL_tests")
-execute_process(COMMAND "createdb" "ULL_tests")
-execute_process(COMMAND "psql" "ULL_tests" INPUT_FILE "${CMAKE_SOURCE_DIR}/run-poc/atom.sql")
-message("\nCreated database ULL_tests.\n")
-
-execute_process(COMMAND "dropdb" "ULL_calcMI_clique_test")
-execute_process(COMMAND "createdb" "ULL_calcMI_clique_test")
-execute_process(COMMAND "psql" "ULL_calcMI_clique_test" INPUT_FILE "${CMAKE_SOURCE_DIR}/run-poc/atom.sql")
-message("\nCreated database ULL_calcMI_clique_test.\n")
-
-execute_process(COMMAND "dropdb" "ULL_calcMI_any_test")
-execute_process(COMMAND "createdb" "ULL_calcMI_any_test")
-execute_process(COMMAND "psql" "ULL_calcMI_any_test" INPUT_FILE "${CMAKE_SOURCE_DIR}/run-poc/atom.sql")
-message("\nCreated database ULL_calcMI_any_test.\n")
-
-# The current ULL pipeline is tokenization-agnostic, so the input
-# should be pre-tokenized by some other method. The pipeline only
-# splits sentences by spaces. For the tests to work, we need to
-# remove the content of the affix-file in the link-grammar dictionary
-# for "any" language. For the test suite, it is done below.
-execute_process(COMMAND "echo ''" OUTPUT_FILE "usr/local/share/link-grammar/any/affix-punc")
+ENABLE_TESTING()
 
 # Add Unit tests
 ADD_GUILE_TEST(UllPairCounting pair-count-tests.scm)


### PR DESCRIPTION
Attending issue https://github.com/opencog/learn/issues/6, moved psql database creation for tests to custom target "make db". This should be run before "make test", as it is not triggered automatically at the moment.